### PR TITLE
Install Openwhisk first

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@
 
 # 起動方法
 
+## OpenWhiskのインストール
+
+最初に[OpenWhisk](https://github.com/apache/openwhisk-devtools)を起動します。
+これは、あとでFIWARE OrionコンテナがOpenWhiskのネットワークopenwhisk_defaultを参照するためです。
+
+まず、OpenWhiskを取得します。
+
+```
+git clone https://github.com/apache/openwhisk-devtools.git
+```
+
+OpenWhiskを実行します。
+
+```
+cd openwhisk-devtools/docker-compose/
+make quick-start
+```
+
+## リポジトリの取得
+
 リポジトリのクローンをします。
 
 ```
@@ -75,19 +95,6 @@ docker-compose -f docker-compose-knowage.yaml up -d
 
 
 ## Meteoroidの起動
-
-Meteoroidの起動に必要となる[OpenWhisk](https://github.com/apache/openwhisk-devtools)を取得します。
-
-```
-git clone https://github.com/apache/openwhisk-devtools.git
-```
-
-OpenWhiskを実行します。
-
-```
-cd openwhisk-devtools/docker-compose/
-make quick-start
-```
 
 Meteoroidを起動します。
 


### PR DESCRIPTION
docker-compose.yaml refers network: proxynet -> openwhisk_default (external) and docker-compose stopped with no network error before insatalling openwhisk.

So Install sequence is as bellow:
1. openwhisk
2. orion & cygnus
3. wirecloud
4. knowage
5. meteoroid